### PR TITLE
Update cocoapod configuration to point to release tag 1.1.0

### DIFF
--- a/Trustylib.podspec
+++ b/Trustylib.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Trustylib"
-  spec.version      = "1.0.0"
+  spec.version      = "1.1.0"
   spec.summary      = "Trusted shops library for the iOS platform"
   spec.description  = <<-DESC
   Trustylib iOS library provides UI widgets for displaying trustmark logo and shop reviews in iOS applications. It provides an easy integration for these widgets with very little amount of code, please see the readme section for more details.


### PR DESCRIPTION
## Description
Updated Cocoapods configuration to point to release tag 1.1.0 for the new release.
