### PR TITLE
Update minimum required iOS version to iOS 14 for cocoapod and SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Trustylib",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v14)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Trustylib/Views/TrustbadgeView.swift
+++ b/Sources/Trustylib/Views/TrustbadgeView.swift
@@ -98,7 +98,7 @@ public struct TrustbadgeView: View {
             // This spacer helps in keeping the trustmark icon and expanding view
             // aligned to the right
             if self.alignment == .trailing {
-                Spacer()
+                Spacer(minLength: 0)
             }
             
             ZStack(alignment: self.alignment == .leading ? .leading : .trailing) {
@@ -174,7 +174,7 @@ public struct TrustbadgeView: View {
             // This spacer helps in keeping the trustmark icon and expanding view
             // aligned to the left
             if self.alignment == .leading {
-                Spacer()
+                Spacer(minLength: 0)
             }
         }
     }

--- a/Trustylib.podspec
+++ b/Trustylib.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.license      = "MIT"
   spec.author       = { "Trusted Shops AG" => "https://www.trustedshops.com/" }
 
-  spec.platform     = :ios, "13.0"
+  spec.platform     = :ios, "14.0"
   spec.swift_versions = "5.3"
   spec.source = { :git => "https://github.com/trustedshops-public/etrusted-ios-trustbadge-library.git", :tag => "#{spec.version}"}
   spec.source_files = "Sources/Trustylib/**/*.{swift}"


### PR DESCRIPTION
## Description
Widget views now use StateObject for maintaining view model states. This requires iOS version 14.
Therefore updated Cocoapod and SPM configuration to use iOS 14 for the minimum required iOS version.
