### PR TITLE
Merge buyer protection currency (chf, euro, gbp, pln, nok, sek, dkk, ron and czk) support with develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ In case, your trust certificate gets expired, the Trustmark widgets is presented
 `Shop Grade` widget expands to show shop rating and status (Excellent, Good, Fair, etc) with a nice animation effect. The widget however shows the aggregate rating and status only, it doesn't show shop actual reviews' details like review text, review date, attachments, etc. <br>
 ![shop-grade](https://user-images.githubusercontent.com/27926337/233945935-5002f633-3fef-49d2-9da4-ebd5d648495b.gif)
 
-
-`Buyer Protection` widget shows details about protection amount. This widget is available in `CocoadPod version 1.1.0+` and `Swift Package version 1.1.0+`). It currently has support for `EURO` currency only, support for more currencies will be available soon.<br>
+`Buyer Protection` widget shows details about protection amount. This widget is available in `CocoadPod version 1.1.0+` and `Swift Package version 1.1.0+`).<br>
 ![buyer-protection](https://user-images.githubusercontent.com/27926337/233946329-21ef1b31-7d06-492a-b0db-ced72eeddb23.gif)
 
 `Product Grade` widget shows product image, rating and status (Excellent, Good, Fair, etc) with an animated user interface. This widget is available in `CocoadPod version 1.2.0+` and `Swift Package version 1.2.0+`).<br>
 ![product-grade](https://user-images.githubusercontent.com/27926337/233946381-e363ecd9-8e8b-4cc0-beb2-0d8797113f2a.gif)
-
 
 ## 1. Installation ##
 

--- a/Sources/Trustylib/Models/BuyerProtectionDetailsModel.swift
+++ b/Sources/Trustylib/Models/BuyerProtectionDetailsModel.swift
@@ -45,6 +45,12 @@ class BuyerProtectionDetails: Codable {
     let maxProtectionAmount: String
     let maxProtectionDuration: String
     
+    /// Returns protection currency enum
+    var protectionCurrency: CurrencyCode {
+        let currency = CurrencyCode(rawValue: self.mainProtectionCurrency.lowercased()) ?? .eur
+        return currency
+    }
+    
     /// Returns buyer protection amount rounded to 2 decimal points
     var protectionAmountFormatted: String {
         guard let protectionAmount = Float(self.maxProtectionAmount) else {
@@ -54,7 +60,8 @@ class BuyerProtectionDetails: Codable {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.usesGroupingSeparator = true
-        formatter.currencyCode = CurrencyCode.euro.code
+        formatter.currencyCode = self.protectionCurrency.code
+        formatter.currencySymbol = self.protectionCurrency.symbol
         formatter.maximumFractionDigits = 0
 
         let number = NSNumber(value: protectionAmount)

--- a/Sources/Trustylib/Models/BuyerProtectionDetailsModel.swift
+++ b/Sources/Trustylib/Models/BuyerProtectionDetailsModel.swift
@@ -53,7 +53,7 @@ class BuyerProtectionDetails: Codable {
     
     /// Returns buyer protection amount rounded to 2 decimal points
     var protectionAmountFormatted: String {
-        guard let protectionAmount = Float(self.maxProtectionAmount) else {
+        guard let protectionAmount = Double(self.maxProtectionAmount) else {
             return self.maxProtectionAmount
         }
         
@@ -62,7 +62,7 @@ class BuyerProtectionDetails: Codable {
         formatter.usesGroupingSeparator = true
         formatter.currencyCode = self.protectionCurrency.code
         formatter.currencySymbol = self.protectionCurrency.symbol
-        formatter.maximumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
 
         let number = NSNumber(value: protectionAmount)
         return formatter.string(from: number)!

--- a/Sources/Trustylib/Models/CurrencyCode.swift
+++ b/Sources/Trustylib/Models/CurrencyCode.swift
@@ -30,8 +30,16 @@ import Foundation
 /**
  CurrencyCode enum contains details like currency code, symbol, etc
  */
-enum CurrencyCode: Codable {
-    case euro, gbp
+enum CurrencyCode: String, Codable {
+    case chf // Swiss Franc
+    case eur // Euro
+    case gbp // Pound Sterling
+    case pln // Polish złoty
+    case nok // Norwegian krone
+    case sek // Swedish krona
+    case dkk // Danish krone
+    case ron // Romanian leu
+    case czk // Czech koruna
     
     // MARK: Public properties
     
@@ -40,8 +48,32 @@ enum CurrencyCode: Codable {
      */
     var code: String {
         switch self {
-        case .euro: return "EURO"
+        case .chf: return "CHF"
+        case .eur: return "EURO"
         case .gbp: return "GBP"
+        case .pln: return "PLN"
+        case .nok: return "NOK"
+        case .sek: return "SEK"
+        case .dkk: return "DKK"
+        case .ron: return "RON"
+        case .czk: return "CZK"
+        }
+    }
+    
+    /**
+     Returns currency code
+     */
+    var symbol: String {
+        switch self {
+        case .chf: return "CHF"
+        case .eur: return "€"
+        case .gbp: return "£"
+        case .pln: return "zł"
+        case .nok: return "kr"
+        case .sek: return "kr"
+        case .dkk: return "kr"
+        case .ron: return "L"
+        case .czk: return "Kč"
         }
     }
 }

--- a/Sources/Trustylib/Models/CurrencyCode.swift
+++ b/Sources/Trustylib/Models/CurrencyCode.swift
@@ -69,9 +69,7 @@ enum CurrencyCode: String, Codable {
         case .eur: return "€"
         case .gbp: return "£"
         case .pln: return "zł"
-        case .nok: return "kr"
-        case .sek: return "kr"
-        case .dkk: return "kr"
+        case .nok, .sek, .dkk: return "kr"
         case .ron: return "L"
         case .czk: return "Kč"
         }

--- a/Tests/TrustylibTests/BuyerProtectionDetailsModelTests.swift
+++ b/Tests/TrustylibTests/BuyerProtectionDetailsModelTests.swift
@@ -67,6 +67,12 @@ final class BuyerProtectionDetailsModelTests: XCTestCase {
                        "Buyer protection details object should have correct currency code")
         XCTAssertTrue(buyerProtectionDetailsModel.guarantee.maxProtectionDuration == "30",
                        "Buyer protection details object should have correct protection duration")
+        XCTAssertTrue(buyerProtectionDetailsModel.guarantee.protectionCurrency == .chf,
+                       "Buyer protection details object should have correct protection currency")
+        XCTAssertTrue(buyerProtectionDetailsModel.guarantee.protectionCurrency.code == "CHF",
+                       "Buyer protection details object should have correct protection currency code")
+        XCTAssertTrue(buyerProtectionDetailsModel.guarantee.protectionCurrency.symbol == "CHF",
+                       "Buyer protection details object should have correct protection currency symbol")
     }
     
     func testBuyerProtectionDetailsReturnsCorrectFormattedStringForProtectionAmount() {
@@ -77,7 +83,8 @@ final class BuyerProtectionDetailsModelTests: XCTestCase {
         
         XCTAssertTrue(buyerProtectionDetailsModel.guarantee.maxProtectionAmount == "4000.00",
                        "Buyer protection details object should have correct protection amount")
-        XCTAssertTrue(buyerProtectionDetailsModel.guarantee.protectionAmountFormatted == "€4,000",
+        let protectionAmountFormatted = buyerProtectionDetailsModel.guarantee.protectionAmountFormatted
+        XCTAssertTrue(protectionAmountFormatted.contains("CHF 4,000"),
                        "Buyer protection details object should return valid formatted protection amount")
     }
 

--- a/Tests/TrustylibTests/CurrencyCodeTests.swift
+++ b/Tests/TrustylibTests/CurrencyCodeTests.swift
@@ -1,0 +1,105 @@
+//
+//  Copyright (C) 2023 Trusted Shops GmbH
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+//  Created by Prem Pratap Singh on 24/04/23.
+//
+
+
+import XCTest
+@testable import Trustylib
+
+/**
+ CurrencyCodeTests tests currency code enum initialization and accuracy of currency code and symol
+ */
+final class CurrencyCodeTests: XCTestCase {
+    
+    func testCurrencyCodeIntializesWithCorrectCurrency() {
+        let currencyCode = CurrencyCode(rawValue: "chf")
+        XCTAssertTrue(
+            currencyCode?.symbol == "CHF",
+            "Currency code should be initialized with correct currency code"
+        )
+    }
+    
+    func testCurrencyCodeReturnsValidCodeAndSymbol() {
+        let currencyCodeChf = CurrencyCode(rawValue: "chf")
+        XCTAssertTrue(
+            currencyCodeChf?.code == "CHF",
+            "Currency code should return correct currency code"
+        )
+        XCTAssertTrue(
+            currencyCodeChf?.symbol == "CHF",
+            "Currency code should return correct currency symbol"
+        )
+        
+        let currencyCodeEur = CurrencyCode(rawValue: "eur")
+        XCTAssertTrue(
+            currencyCodeEur?.code == "EURO",
+            "Currency code should return correct currency code"
+        )
+        XCTAssertTrue(
+            currencyCodeEur?.symbol == "€",
+            "Currency code should return correct currency symbol"
+        )
+        
+        let currencyCodeGbp = CurrencyCode(rawValue: "gbp")
+        XCTAssertTrue(
+            currencyCodeGbp?.code == "GBP",
+            "Currency code should return correct currency code"
+        )
+        XCTAssertTrue(
+            currencyCodeGbp?.symbol == "£",
+            "Currency code should return correct currency symbol"
+        )
+        
+        let currencyCodePln = CurrencyCode(rawValue: "pln")
+        XCTAssertTrue(
+            currencyCodePln?.code == "PLN",
+            "Currency code should return correct currency code"
+        )
+        XCTAssertTrue(
+            currencyCodePln?.symbol == "zł",
+            "Currency code should return correct currency symbol"
+        )
+        
+        let currencyCodeNok = CurrencyCode(rawValue: "nok")
+        XCTAssertTrue(
+            currencyCodeNok?.code == "NOK",
+            "Currency code should return correct currency code"
+        )
+        XCTAssertTrue(
+            currencyCodeNok?.symbol == "kr",
+            "Currency code should return correct currency symbol"
+        )
+        
+        let currencyCodeCzk = CurrencyCode(rawValue: "czk")
+        XCTAssertTrue(
+            currencyCodeCzk?.code == "CZK",
+            "Currency code should return correct currency code"
+        )
+        XCTAssertTrue(
+            currencyCodeCzk?.symbol == "Kč",
+            "Currency code should return correct currency symbol"
+        )
+    }
+}

--- a/Trustylib.xcodeproj/project.pbxproj
+++ b/Trustylib.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		C1A983F929F59C4E00D83BBF /* product_ratings_service_response.json in Resources */ = {isa = PBXBuildFile; fileRef = C1A983F329F598A600D83BBF /* product_ratings_service_response.json */; };
 		C1A983FB29F5A1B100D83BBF /* ProductRatingsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A983FA29F5A1B100D83BBF /* ProductRatingsModelTests.swift */; };
 		C1A983FD29F5A5BF00D83BBF /* ProductDetailsDataServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A983FC29F5A5BF00D83BBF /* ProductDetailsDataServiceTests.swift */; };
+		C1A401EA29F6CCBC008B1184 /* CurrencyCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A401E929F6CCBC008B1184 /* CurrencyCodeTests.swift */; };
 		C1B99E5229AE0A9B00F80599 /* ShopGradeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B99E5129AE0A9B00F80599 /* ShopGradeViewModelTests.swift */; };
 		C1B99E5429AE102B00F80599 /* TrustbadgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B99E5329AE102B00F80599 /* TrustbadgeTests.swift */; };
 		C1B99E5629AE282900F80599 /* TrustbadgeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B99E5529AE282900F80599 /* TrustbadgeViewTests.swift */; };
@@ -188,6 +189,7 @@
 		C1A983F529F598DD00D83BBF /* ProductDetailsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsModelTests.swift; sourceTree = "<group>"; };
 		C1A983FA29F5A1B100D83BBF /* ProductRatingsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRatingsModelTests.swift; sourceTree = "<group>"; };
 		C1A983FC29F5A5BF00D83BBF /* ProductDetailsDataServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsDataServiceTests.swift; sourceTree = "<group>"; };
+		C1A401E929F6CCBC008B1184 /* CurrencyCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyCodeTests.swift; sourceTree = "<group>"; };
 		C1B99E5129AE0A9B00F80599 /* ShopGradeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopGradeViewModelTests.swift; sourceTree = "<group>"; };
 		C1B99E5329AE102B00F80599 /* TrustbadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustbadgeTests.swift; sourceTree = "<group>"; };
 		C1B99E5529AE282900F80599 /* TrustbadgeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustbadgeViewTests.swift; sourceTree = "<group>"; };
@@ -479,6 +481,7 @@
 				C1270A9229F5ABEF00388694 /* ProductGradeViewModelTests.swift */,
 				C1270A9429F5B1A700388694 /* ProductGradeViewTests.swift */,
 				C1A401E729F6AA15008B1184 /* GradeAndRatingViewTests.swift */,
+				C1A401E929F6CCBC008B1184 /* CurrencyCodeTests.swift */,
 			);
 			path = TrustylibTests;
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 				C190465229D5A2B10054BEE4 /* BuyerProtectionDataServiceTests.swift in Sources */,
 				C1C33E98299B7DFD00676059 /* ClientAuthenticationTests.swift in Sources */,
 				C1B99E5C29AE3F1A00F80599 /* TrustbadgeViewWrapperTests.swift in Sources */,
+				C1A401EA29F6CCBC008B1184 /* CurrencyCodeTests.swift in Sources */,
 				C1C33EA7299CAD7000676059 /* AggregateRatingsModelTests.swift in Sources */,
 				C1B99E5229AE0A9B00F80599 /* ShopGradeViewModelTests.swift in Sources */,
 				C1C33E9C299B950E00676059 /* ShopGradeDataServiceTests.swift in Sources */,


### PR DESCRIPTION
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates - https://etrustedmobile.atlassian.net/browse/MAD-215 [iOS] Trustylib V2.5 Buyer protection currency management

## Description
Added buyer protection currency support for `chf, euro, gbp, pln, nok, sek, dkk, ron and czk` currencies. 
The same set of currencies are being supported by the web trustbadge component. This JS script has details about  supported currencies - https://github.com/trustedshops/trustbadge/blob/main/business-logic/app/shared/format.ts 
