### PR TITLE
Merge Trustcardview initialisation related changes with the develop branch

### DIFF
--- a/Sources/Trustylib/ViewModels/TrustbadgeViewModel.swift
+++ b/Sources/Trustylib/ViewModels/TrustbadgeViewModel.swift
@@ -125,18 +125,16 @@ class TrustbadgeViewModel: ObservableObject {
         tsId: String,
         channelId: String? = nil,
         productId: String? = nil,
-        orderDetails: Binding<OrderDetailsModel?> = .constant(nil),
-        trustCardState: Binding<TrustcardState?> = .constant(nil),
         context: TrustbadgeContext,
         alignment: TrustbadgeViewAlignment = .leading) {
             self.tsId = tsId
             self.channelId = channelId
             self.productId = productId
-            self.orderDetails = orderDetails
-            self.trustCardState = trustCardState
             self.context = context
             self.alignment = alignment
             self.iconImageName = TrustbadgeState.default(false).iconImageName
+            self.orderDetails = .constant(nil)
+            self.trustCardState = .constant(nil)
             
             self.setTrustcardVisibilityState()
     }

--- a/Sources/Trustylib/Views/TrustbadgeView.swift
+++ b/Sources/Trustylib/Views/TrustbadgeView.swift
@@ -62,8 +62,6 @@ public struct TrustbadgeView: View {
         tsId: String,
         channelId: String? = nil,
         productId: String? = nil,
-        orderDetails: Binding<OrderDetailsModel?> = .constant(nil),
-        trustCardState: Binding<TrustcardState?> = .constant(nil),
         context: TrustbadgeContext,
         alignment: TrustbadgeViewAlignment = .leading
     ) {
@@ -72,8 +70,6 @@ public struct TrustbadgeView: View {
                 tsId: tsId,
                 channelId: channelId,
                 productId: productId,
-                orderDetails: orderDetails,
-                trustCardState: trustCardState,
                 context: context,
                 alignment: alignment
             )

--- a/Sources/Trustylib/Views/TrustbadgeViewWrapper.swift
+++ b/Sources/Trustylib/Views/TrustbadgeViewWrapper.swift
@@ -44,8 +44,6 @@ import SwiftUI
         tsId: String,
         channelId: String? = nil,
         productId: String? = nil,
-        orderDetails: OrderDetailsModel? = nil,
-        trustCardState: TrustcardState = .classicProtection,
         context: TrustbadgeContext,
         alignment: TrustbadgeViewAlignment = .leading) -> UIViewController {
         return UIHostingController(
@@ -53,8 +51,6 @@ import SwiftUI
                 tsId: tsId,
                 channelId: channelId,
                 productId: productId,
-                orderDetails: .constant(orderDetails),
-                trustCardState: .constant(trustCardState),
                 context: context,
                 alignment: alignment
             )

--- a/Tests/TrustylibTests/TrustbadgeViewTests.swift
+++ b/Tests/TrustylibTests/TrustbadgeViewTests.swift
@@ -64,48 +64,6 @@ final class TrustbadgeViewTests: XCTestCase {
         )
     }
     
-    func testTrustbadgeViewBuyerProtectionInitializesWithCorrectValues() throws {
-        let orderDetails = OrderDetailsModel(number: "123", amount: 789, currency: .eur, paymentType: "credit-card", estimatedDeliveryDate: "23-11-2023", buyerEmail: "abc@xyz.com")
-        
-        let trustbadgeView = TrustbadgeView(
-            tsId: self.tsId,
-            channelId: self.channelId,
-            orderDetails: .constant(orderDetails)  ,
-            trustCardState: .constant(.classicProtection),
-            context: .buyerProtection
-        )
-        
-        XCTAssertNotNil(
-            trustbadgeView.currentViewModel,
-            "TrustbadgeView should initialize view model during initialization"
-        )
-        
-        XCTAssert(
-            trustbadgeView.currentViewModel.tsId == self.tsId,
-            "TrustbadgeView should set correct tsid during initialization"
-        )
-        
-        XCTAssert(
-            trustbadgeView.currentViewModel.channelId == self.channelId,
-            "TrustbadgeView should set correct channel id during initialization"
-        )
-        
-        XCTAssertNotNil(
-            trustbadgeView.currentViewModel.orderDetails,
-            "TrustbadgeView should set correct order details during initialization"
-        )
-        
-        XCTAssertNotNil(
-            trustbadgeView.currentViewModel.trustCardState,
-            "TrustbadgeView should set correct trustcard state during initialization"
-        )
-        
-        XCTAssert(
-            trustbadgeView.currentViewModel.context == .buyerProtection,
-            "TrustbadgeView should set correct context during initialization"
-        )
-    }
-    
     func testTrustbadgeViewBodyIsNotNilForShopGradeContext() {
         let trustbadgeView = TrustbadgeView(
             tsId: self.tsId,


### PR DESCRIPTION
TrustCard view designs are done but aren't proposed to release for the client till the fully functional TrustCard is implemented that includes backend API and business logic integration.

So for now, TrustCard view related parameters have been removed from the Trustbadge view initialisation workflow.
